### PR TITLE
:bug: Fix typo when waiting for password prompt

### DIFF
--- a/maintenance/change_credentials.py
+++ b/maintenance/change_credentials.py
@@ -171,7 +171,7 @@ def change_pass(old_pass):
     :return: new password string
     """
     child = pexpect.spawn('passwd')
-    child.expect('password: ')
+    child.expect('Password: ')
     child.sendline(old_pass)
     i = child.expect(['New password: ', 'Password incorrect: try again'])
 


### PR DESCRIPTION
* The first prompt appears as "Current Password:"

        Changing password for user espadev.
        Current Password:
        New password:
        Retype new password:
        passwd: all authentication tokens updated successfully.