### PR TITLE
Remove Crontab

### DIFF
--- a/maintenance/change_credentials.py
+++ b/maintenance/change_credentials.py
@@ -168,7 +168,7 @@ def run():
     # broad exception handling so whatever traceback gets generated
     # is sent out in the email
     msg = 'General Failure'
-    success = 'Failure'
+    status = 'Failure'
 
     username, cfg_path = arg_parser()
     db_info = get_cfg(cfg_path, section='config')
@@ -179,11 +179,11 @@ def run():
         new_pass = change_pass(old_pass)
         update_db(new_pass, db_info)
         msg = 'User: {0} password has been updated'.format(username)
-        success = 'Successful'
+        status = 'Successful'
     except Exception:
         msg = str(traceback.format_exc())
     finally:
-        send_email(sender, reciever, EMAIL_SUBJECT.format(success), msg)
+        send_email(sender, reciever, EMAIL_SUBJECT.format(status), msg)
 
 
 if __name__ == '__main__':

--- a/maintenance/utils.py
+++ b/maintenance/utils.py
@@ -1,3 +1,4 @@
+import sys
 import smtplib
 from email.mime.text import MIMEText
 import ConfigParser
@@ -9,7 +10,7 @@ from dbconnect import DBConnect
 import paramiko
 
 
-def get_cfg(cfg_path=None):
+def get_cfg(cfg_path=None, section=''):
     """
     Retrieve the configuration information from the .cfgnfo file
     located in the current user's home directory
@@ -21,6 +22,10 @@ def get_cfg(cfg_path=None):
     if not cfg_path:
         cfg_path = os.path.join(os.path.expanduser('~'), '.usgs', '.cfgnfo')
 
+    if not os.path.exists(cfg_path):
+        print('! DB configuration not found: {c}'.format(c=cfg_path))
+        sys.exit(1)
+
     cfg_info = {}
     config = ConfigParser.ConfigParser()
     config.read(cfg_path)
@@ -29,6 +34,12 @@ def get_cfg(cfg_path=None):
         cfg_info[sect] = {}
         for opt in config.options(sect):
             cfg_info[sect][opt] = config.get(sect, opt)
+
+    if section:
+        if section not in cfg_info:
+            print('! Section {s} not found in {c}'.format(s=section, c=cfg_path))
+            sys.exit(1)
+        cfg_info = cfg_info[section]
 
     return cfg_info
 

--- a/maintenance/utils.py
+++ b/maintenance/utils.py
@@ -49,7 +49,7 @@ def send_email(sender, recipient, subject, body):
     Send out an email to give notice of success or failure
 
     :param sender: who the email is from
-    :type sender: string
+    :type sender: list
     :param recipient: list of recipients of the email
     :type recipient: list
     :param subject: subject line of the email


### PR DESCRIPTION
* Removes the crontab functionality.
* Adds "-c/--configfile" commandline argument (defaults back to $ESPA_CONFIG_PATH if defined)
  * Still uses ~/.usgs/.cfgnfo by default
* Changes "success" variable to "status" (for email subject line)