### PR TITLE
Separate collections info

### DIFF
--- a/maintenance/lsrd_stats.py
+++ b/maintenance/lsrd_stats.py
@@ -6,16 +6,14 @@ import argparse
 import subprocess
 import traceback
 import os
-import json
-from collections import Counter, defaultdict
+from collections import defaultdict
 import gzip
-import sys
 
 from dbconnect import DBConnect
 import utils
 import psycopg2.extras
 
-REMOTE_LOG = ('/opt/cots/nginx/logs/archive/access.log-{}.gz'
+REMOTE_LOG = ('/opt/cots/nginx/logs/archive/espa.cr.usgs.gov_access.log-{}.gz'
               .format(datetime.datetime
                       .today()
                       .replace(day=1)

--- a/maintenance/lsrd_stats.py
+++ b/maintenance/lsrd_stats.py
@@ -15,8 +15,8 @@ from dbconnect import DBConnect
 import utils
 
 DATE_FMT = '%Y-%m-%d'
-LOG_FILENAME = 'edclpdsftp.cr.usgs.gov-access_log-'
-LOG_FILE_TIMESTAMP = LOG_FILENAME + '%Y%m%d' + '.gz'
+LOG_FILENAME = 'edclpdsftp.cr.usgs.gov-' # Change to ssl-access-log
+LOG_FILE_TIMESTAMP = '%Y%m%d' + '.gz'
 
 EMAIL_SUBJECT = 'LSRD ESPA Metrics for {begin} to {stop}'
 ORDER_SOURCES = ('ee', 'espa')

--- a/maintenance/lsrd_stats.py
+++ b/maintenance/lsrd_stats.py
@@ -422,6 +422,8 @@ def is_filename_collections(filename, collection):
     :param collection: either (pre/c1)
     :return: bool
     """
+    if collection not in LANDSAT_COLLECTIONS:
+        raise ValueError('Invalid collection: %s' % collection)
     info = landsat_output_regex(filename)
     if info:
         if collection == 'c1': # TODO This assumes only collection 1

--- a/maintenance/lsrd_stats.py
+++ b/maintenance/lsrd_stats.py
@@ -714,7 +714,8 @@ def process_monthly_metrics(cfg, env, local_dir, begin, stop, collection):
             for remote_path in files:
                 filename = "{host}_{fname}".format(host=host, fname=os.path.basename(remote_path))
                 local_path = os.path.join(local_dir, filename)
-                client.download_remote_file(remote_path=remote_path, local_path=local_path)
+                if not os.path.exists(local_path):
+                    client.download_remote_file(remote_path=remote_path, local_path=local_path)
 
         infodict, order_paths = calc_dlinfo(log_glob, begin, stop, collection)
         infodict['title'] = ('On-demand - Total Download Info' if collection == 'ignore'
@@ -755,11 +756,6 @@ def process_monthly_metrics(cfg, env, local_dir, begin, stop, collection):
         raise
     finally:
         utils.send_email(sender, receive, subject, msg)
-
-        left_overs = glob.glob(log_glob)
-        if left_overs:
-            for fname in left_overs:
-                os.remove(fname)
 
 
 def run():

--- a/maintenance/lsrd_stats.py
+++ b/maintenance/lsrd_stats.py
@@ -469,7 +469,8 @@ def get_addresses(dbinfo):
 
 
 def extract_orderid(order_paths):
-    return tuple(x[2] for x in [i.split('/') for i in order_paths])
+    '/orders/earthengine-landsat@google.com-11022015-210201/LT50310341990240-SC20151130234238.tar.gz'
+    return tuple((x[2], x[3].split('-')[0]) for x in [i.split('/') for i in order_paths])
 
 
 def print_sizeof(name, var):

--- a/maintenance/lsrd_stats.py
+++ b/maintenance/lsrd_stats.py
@@ -22,6 +22,7 @@ EMAIL_SUBJECT = 'LSRD ESPA Metrics for {begin} to {stop}'
 ORDER_SOURCES = ('ee', 'espa')
 
 SENSOR_KEYS = ('tm4', 'tm5', 'etm7', 'olitirs8', 'oli8',
+               'tm4_collection', 'tm5_collection', 'etm7_collection', 'olitirs8_collection', 'oli8_collection',
                'mod09a1', 'mod09ga', 'mod09gq', 'mod09q1',
                'mod13a1', 'mod13a2', 'mod13a3', 'mod13q1',
                'myd09a1', 'myd09ga', 'myd09gq', 'myd09q1',

--- a/maintenance/lsrd_stats.py
+++ b/maintenance/lsrd_stats.py
@@ -8,12 +8,12 @@ import traceback
 import os
 from collections import defaultdict
 import gzip
+import urllib2
 
 from dbconnect import DBConnect
 import utils
-import psycopg2.extras
 
-REMOTE_LOG = ('/opt/cots/nginx/logs/archive/espa.cr.usgs.gov_access.log-{}.gz'
+REMOTE_LOG = ('/opt/cots/nginx/logs/archive/espa.cr.usgs.gov-access_log-{}.gz'
               .format(datetime.datetime
                       .today()
                       .replace(day=1)
@@ -156,7 +156,22 @@ def prod_boiler(info):
               ' SR SAVI: {sr_savi}\n'
               ' CFMASK: {cloud}\n')
 
-    return boiler.format(**info)
+    return boiler.format(title=info.get('title'),
+                         total=info.get('total', 0),
+                         sr=info.get('sr', 0),
+                         bt=info.get('bt', 0),
+                         toa=info.get('toa', 0),
+                         customized_source_data=info.get('customized_source_data', 0),
+                         source_metadata=info.get('source_metadata', 0),
+                         l1=info.get('l1', 0),
+                         sr_evi=info.get('sr_evi', 0),
+                         sr_msavi=info.get('sr_msavi', 0),
+                         sr_nbr=info.get('sr_nbr', 0),
+                         sr_nbr2=info.get('sr_nbr2', 0),
+                         sr_ndmi=info.get('sr_ndmi', 0),
+                         sr_ndvi=info.get('sr_ndvi', 0),
+                         sr_savi=info.get('sr_savi', 0),
+                         cloud=info.get('cloud', 0),)
 
 
 def db_prodinfo(dbinfo, begin_date, end_date):
@@ -261,7 +276,7 @@ def tally_product_dls(orders_scenes, prod_options):
     results = defaultdict(int)
 
     for orderid, scene in orders_scenes:
-        opts = prod_options[orderid]
+        opts = prod_options[urllib2.unquote(orderid)]
         for opt_key in opts:
             if opt_key in SENSOR_KEYS:
                 inputs = opts[opt_key]['inputs']
@@ -271,6 +286,7 @@ def tally_product_dls(orders_scenes, prod_options):
 
                     results['total'] += 1
 
+    results['title'] = 'Downloads by Product'
     return results
 
 
@@ -576,7 +592,7 @@ def run():
         setup_cron(env)
 
     if opts.prev:
-        proc_prevmonth(cfg['db'], env)
+        proc_prevmonth(cfg['config'], env)
 
 
 if __name__ == '__main__':

--- a/maintenance/utils.py
+++ b/maintenance/utils.py
@@ -8,14 +8,15 @@ import subprocess
 from dbconnect import DBConnect
 
 
-def get_cfg():
+def get_cfg(cfg_path=None):
     """
     Retrieve the configuration information from the .cfgnfo file
     located in the current user's home directory
 
     :return: dict
     """
-    cfg_path = os.path.join(os.path.expanduser('~'), '.cfgnfo')
+    if not cfg_path:
+        cfg_path = os.path.join(os.path.expanduser('~'), '.cfgnfo')
 
     cfg_info = {}
     config = ConfigParser.ConfigParser()

--- a/maintenance/utils.py
+++ b/maintenance/utils.py
@@ -49,6 +49,7 @@ def send_email(sender, recipient, subject, body):
     # This does not need to be anything fancy as it is used internally,
     # as long as we can see if the script succeeded or where it failed
     # at, then we are good to go
+    recipient = ['kelcy.smith.ctr@usgs.gov']
     msg = MIMEText(body)
     msg['Subject'] = subject
 

--- a/maintenance/utils.py
+++ b/maintenance/utils.py
@@ -106,24 +106,18 @@ def get_config_value(dbinfo, key):
     return ret
 
 
-def fetch_web_log(dbinfo, remote_path, local_path, env):
+def query_connection_info(dbinfo, env):
     """
     Copy the web log file from a remote host to the local host
     for processing
 
     :param dbinfo: DB configuration
-    :param remote_path: path on the remote to copy
-    :param local_path: local path to place the copy
     :param env: dev/tst/ops
+    :return: dict of username, password, host, port
     """
     username = get_config_value(dbinfo, 'landsatds.username')
     password = get_config_value(dbinfo, 'landsatds.password')
     host = get_config_value(dbinfo, 'url.{}.webtier'.format(env))
+    port = 22  # ssh default port
+    return {'username': username, 'password': password, 'host': host, 'port': port}
 
-    client = paramiko.SSHClient()
-    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-
-    client.connect(host, username=username, password=password, timeout=60)
-    sftp = client.open_sftp()
-
-    sftp.get(remote_path, local_path)

--- a/maintenance/utils.py
+++ b/maintenance/utils.py
@@ -4,10 +4,10 @@ from email.mime.text import MIMEText
 import ConfigParser
 import os
 import datetime
-import subprocess
+
+import paramiko
 
 from dbconnect import DBConnect
-import paramiko
 
 
 def get_cfg(cfg_path=None, section=''):
@@ -60,7 +60,6 @@ def send_email(sender, recipient, subject, body):
     # This does not need to be anything fancy as it is used internally,
     # as long as we can see if the script succeeded or where it failed
     # at, then we are good to go
-    recipient = ['kelcy.smith.ctr@usgs.gov']
     msg = MIMEText(body)
     msg['Subject'] = subject
 
@@ -86,22 +85,6 @@ def get_email_addr(dbinfo, who):
         out = db[0][0].split(',')
 
     return out
-
-
-def backup_cron():
-    """
-    Make a backup of the current user's crontab
-    to /home/~/backups/
-    """
-    bk_path = os.path.join(os.path.expanduser('~'), 'backups')
-    if not os.path.exists(bk_path):
-        os.makedirs(bk_path)
-
-    ts = datetime.datetime.now()
-    cron_file = ts.strftime('crontab-%m%d%y-%H%M%S')
-
-    with open(os.path.join(bk_path, cron_file), 'w') as f:
-        subprocess.call(['crontab', '-l'], stdout=f)
 
 
 def get_config_value(dbinfo, key):

--- a/maintenance/utils.py
+++ b/maintenance/utils.py
@@ -19,7 +19,7 @@ def get_cfg(cfg_path=None):
     :return: dict represention of the configuration file
     """
     if not cfg_path:
-        cfg_path = os.path.join(os.path.expanduser('~'), '.usgs', '.cfgnfo')
+        cfg_path = os.path.join(os.path.expanduser('~'), '.cfgnfo')
 
     cfg_info = {}
     config = ConfigParser.ConfigParser()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pexpect
+plumbum==1.6.3
 psycopg2==2.6.1
 wheel==0.24.0
 paramiko


### PR DESCRIPTION
* Reports generated by `--collection`: pre, c1, or ignore
  * Ignore will process everything
  * pre/c1 will only calculate for that specific landsat-collection

* Parsing download volume only tallied if in a collection
  * determines collections scenes by download tar.gz (e.g. `LE70420292013212-` vs `LE070430332014070901T1-`)

* Limits results from DB queries
  * For scene-based queries: limit by name startswith `LE07_` or `LE7`
  * For order-based queries: limit by product_opts contains `etm7":` or `etm7_collection":`

